### PR TITLE
Start k3s service explicitly

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,3 +18,9 @@
     path: '{{ k3s_installer.path }}'
     state: absent
   check_mode: false
+
+- name: Start k3s
+  service:
+    name: k3s
+    enabled: true
+    state: started

--- a/tasks/k3s_install.yml
+++ b/tasks/k3s_install.yml
@@ -23,4 +23,5 @@
     INSTALL_K3S_SELINUX_WARN: 'true'
     INSTALL_K3S_SKIP_SELINUX_RPM: 'true'
     INSTALL_K3S_VERSION: "{{ k3s_version }}"
-    # INSTALL_K3S_SKIP_START: 'true'
+    INSTALL_K3S_SKIP_START: 'true'
+  notify: Start k3s


### PR DESCRIPTION
When the install script starts the service, the installer may pause
waiting for systemd-tty-ask-password-agent