### PR TITLE
Ability to update k3s to latest version in the defined channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Use the following tags to run specific role functions:
   * `k3s-setup` - set-up prerequisites for k3s install
   * `k3s-install` - perform install/upgrade of k3s server
   * `k3s-traefik` - customize traefik configuration
+  * `k3s-update` - update k3s to latest version in defined channel (default is `stable` channel)
+    * NOTE: must explicitly call this tag to run the update tasks
 
 Dependencies
 ------------

--- a/tasks/k3s_update.yml
+++ b/tasks/k3s_update.yml
@@ -1,0 +1,40 @@
+---
+
+- name: Get k3s channel version 
+  shell:
+    cmd: curl -w '%{url_effective}' -L -s -S {{ k3s_channel_install_url }} -o /dev/null | sed -e 's|.*/||'
+  register: k3s_channel_version
+  changed_when: false
+
+- name: Get installed k3s version
+  shell: 
+    cmd: k3s -v | head -1 | awk '{ print $3 }'
+  register: k3s_installed_version
+  changed_when: false
+
+- name: Update k3s to channel version
+  block:
+    - name: Make tempfile for k3s installer
+      tempfile:
+        state: file
+      register: k3s_installer
+      notify: Remove k3s installer
+      check_mode: false
+
+    - name: Get k3s installer
+      get_url:
+        url: '{{ k3s_install_script_url }}'
+        dest: '{{ k3s_installer.path }}'
+
+    - name: Update k3s
+      command:
+        cmd: /bin/sh '{{ k3s_installer.path }}'
+      environment:
+        INSTALL_K3S_CHANNEL: "{{ k3s_channel }}"
+        INSTALL_K3S_EXEC: 'server'
+        INSTALL_K3S_SELINUX_WARN: 'true'
+        INSTALL_K3S_SKIP_SELINUX_RPM: 'true'
+        INSTALL_K3S_VERSION: "{{ k3s_version }}"
+        INSTALL_K3S_SKIP_START: 'true'
+      notify: (Re)Start k3s
+  when: k3s_channel_version.stdout != k3s_installed_version.stdout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,3 +15,8 @@
 - import_tasks: k3s_traefik.yml
   tags:
     - k3s-traefik
+
+- import_tasks: k3s_update.yml
+  tags:
+    - never
+    - k3s-update

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,9 @@
 # URL of the k3s install script
 k3s_install_script_url: "https://get.k3s.io"
 
+# URL of k3s channel install 
+k3s_channel_install_url: "https://update.k3s.io/v1-release/channels/{{ k3s_channel }}"
+
 # Path to the k3s installation configuration file (config.yaml)
 k3s_config_path: "/etc/rancher/k3s"
 


### PR DESCRIPTION
- Puts in place a process to update k3s using the installer script.
- Only way to run this update process is by using the `k3s-update` tag when running the playbook.
- If version latest version in the defined channel matches the installed version, update is skipped.